### PR TITLE
Replace old link in Javadoc by archived version

### DIFF
--- a/src/main/java/de/codecentric/centerdevice/javafxsvg/BufferedImageTranscoder.java
+++ b/src/main/java/de/codecentric/centerdevice/javafxsvg/BufferedImageTranscoder.java
@@ -15,8 +15,8 @@ import org.apache.batik.transcoder.image.ImageTranscoder;
  * "fair use" (because the code is in my opinion too simple to be licensed)
  * 
  * @author bb-generation
- * @see <a href="http://bbgen.net/blog/2011/06/java-svg-to-bufferedimage/">java-
- *      svg-to-bufferedimage</a>
+ * @see <a href="https://web.archive.org/web/20131215231214/http://bbgen.net/blog/2011/06/java-svg-to-bufferedimage/">java-
+ *      svg-to-bufferedimage (as archived by archive.org)</a>
  */
 public class BufferedImageTranscoder extends ImageTranscoder {
 


### PR DESCRIPTION
The linked website is currently down, it is therefore replaced by an archived version from archive.org.

PS: I got an upvote on my [post](http://stackoverflow.com/a/23894292/603003) containing the code you copied and once in a while I tend to check the status of links I provide.